### PR TITLE
V2.5.1 CPU

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-upload_channels:
-  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "2.5.1" %}
 {% set run_all_unittests = False %}
 # Torchaudio and PyTorch are tightly coupled in terms of versions.
-# see compatibility matrix in https://github.com/pytorch/audio/blob/v2.1.2/docs/source/installation.rst#compatibility-matrix
+# check the [releases page](https://github.com/pytorch/audio/releases) for comatibility.
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,6 +48,7 @@ build:
     - "**/libtorch_python.so"       # [linux]
     - "**/libtorchaudio_ffmpeg.so"  # [linux or osx]
     - "**/libtorchaudio.so"         # [linux or osx]
+    - "**/libtorio_ffmpeg.so"       # [unix]
     - "**/libc10.dylib"             # [osx]
     - "**/libtorch_cpu.dylib"       # [osx]
     - "**/libtorch_python.dylib"    # [osx]
@@ -56,6 +57,7 @@ build:
     - "**/torch_python.dll"         # [win]
     - "**/libtorchaudio_ffmpeg.pyd" # [win]
     - "**/libtorchaudio.pyd"        # [win]
+    - "**/libtorio_ffmpeg.pyd"      # [win]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -141,6 +141,8 @@ test:
     - examples
   imports:
     - torchaudio
+    - torch
+    - torch._C
   commands:
     - pip check
     - python test/smoke_test/smoke_test.py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -109,6 +109,11 @@ requirements:
 # because of missing mp3 codec support on ffmpeg for win-64
 {% set tests_to_skip = tests_to_skip + " or test_formats_5_mp3" %}  # [win]
 
+
+{% set integration_tests_to_skip = "_not_a_real_test" %}
+# Segfaulting when building with python 3.13. Passed on a G4 dev instance. Likely OOM.
+{% set integration_tests_to_skip = integration_tests_to_skip + " or test_finetune_asr_model " %}  # [win and py>312]
+
 test:
   source_files:
   {% if run_all_unittests %}
@@ -148,7 +153,7 @@ test:
   commands:
     - pip check
     - python test/smoke_test/smoke_test.py
-    - pytest -v {{ ignore_modules }} test/integration_tests
+    - pytest -v {{ ignore_modules }} -k "not ({{ integration_tests_to_skip }})" test/integration_tests
   {% if run_all_unittests %}
     # to run the tests that require hubert, `dataset` is necessary (currently missing on main)
     - export PYTHONPATH=$PWD/examples/hubert:$PYTHONPATH  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "torchaudio" %}
-{% set version = "2.1.0" %}
+{% set version = "2.5.1" %}
 {% set run_all_unittests = False %}
 # Torchaudio and PyTorch are tightly coupled in terms of versions.
 # see compatibility matrix in https://github.com/pytorch/audio/blob/v2.1.2/docs/source/installation.rst#compatibility-matrix
@@ -10,12 +10,10 @@ package:
 
 source:
   url: https://github.com/pytorch/audio/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 42e3771c8834266de46b19202a36f8db47eb1bb04ac30e8097aa07843f608fcc
+  sha256: 200fbb1234c104a3662b444c0bec2acf4049c4b2113a73c0dc5f4e672cc2a4cc
 
 build:
   number: 0
-  # See above compatibility matrix
-  skip: True  # [py>311]
   # Several test failures on s390x are concerning, particularly the smoke tests in
   # test/torchaudio_unittest/backend/dispatcher/smoke_test.py::test_wav->run_smoke_test->get_save_func(): on s390x the
   # function get_save_func() is unable to instantiate a StreamWriter through the ffmpeg save_audio function
@@ -71,7 +69,7 @@ requirements:
     - setuptools
     - wheel
     - pip
-    - pytorch 2.1.0
+    - pytorch 2.5.1
     - pybind11 2.12.0
     - ffmpeg 6.1.1
     - llvm-openmp  # [osx]
@@ -160,7 +158,7 @@ test:
     - typing
     - parameterized
     - scipy
-    - numpy <1.24
+    - numpy
     - scikit-learn
     - pillow
     - expecttest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -72,7 +72,7 @@ requirements:
     - wheel
     - pip
     - pytorch 2.5.1
-    - pybind11 2.12.0
+    - pybind11 2.12.1
     - ffmpeg 6.1.1
     - llvm-openmp  # [osx]
   run:


### PR DESCRIPTION
torchaudio v2.5.1

**Destination channel:** defaults

### Links

- [PKG-5952](https://anaconda.atlassian.net/browse/PKG-5952) 
- [Upstream repository](https://github.com/pytorch/audio/tree/v2.5.1)


### Explanation of changes:

- Bump version and sha
- Build for 3.13
- Add additional test to make sure we maintain compatibility with pytorch. 

### Notes
- The CUDA variant can be built once we have pytorch 2.5.1 with CUDA support. 

[PKG-5952]: https://anaconda.atlassian.net/browse/PKG-5952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ