### PR TITLE
Update torchaudio to 2.8.0 (pytorch 2.8)

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -5,4 +5,7 @@ set BUILD_SOX=OFF
 set USE_OPENMP=ON
 set BUILD_TORCHAUDIO_PYTHON_EXTENSION=ON
 
+:: Point the build system towards torch .lib files (needed for CUDA builds)
+set LIB=%PREFIX%\Lib\site-packages\torch\lib;%LIB%
+
 %PYTHON% -m pip install . -vv --no-deps --no-build-isolation

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "torchaudio" %}
-{% set version = "2.7.0" %}
+{% set version = "2.8.0" %}
 {% set run_all_unittests = False %}
 # Torchaudio and PyTorch are tightly coupled in terms of versions.
 # check the [releases page](https://github.com/pytorch/audio/releases) for compatibility.
@@ -18,7 +18,7 @@ package:
 
 source:
   url: https://github.com/pytorch/audio/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 31de856d3daa5c1db983eb5b964ed33d54be6e5038d6504181fe51e2d6cc6448
+  sha256: 8809e4b0fa1635a89d5b05fe8e6e1db79fc0cc2052474ef6e76e349755827c12
   patches:
     - patches/0001-add-cuda-cmake-vars.patch
     - patches/0002-replace-FLT_MAX-for-compatibility-with-newer-cudatoo.patch

--- a/recipe/patches/0001-add-cuda-cmake-vars.patch
+++ b/recipe/patches/0001-add-cuda-cmake-vars.patch
@@ -1,28 +1,31 @@
 From: Daniel Petry <dpetry@anaconda.com>
-Subject: [PATCH] Add CMAKE_FIND_ROOT_PATH for conda CUDA sysroot (Linux only)
+Subject: [PATCH] Add CMAKE_FIND_ROOT_PATH for conda CUDA builds
 
-Adds CMAKE_FIND_ROOT_PATH so CMake can find CUDA libraries in the
-conda sysroot on Linux. Guarded with platform check to avoid applying
-Linux-specific paths on Windows CUDA builds.
+Adds CMAKE_FIND_ROOT_PATH so CMake can find CUDA and torch libraries
+in the conda prefix. On Linux, also adds the conda sysroot paths.
+Uses os.uname().machine for architecture-aware paths on Linux.
 
 ---
- tools/setup_helpers/extension.py | 7 +++++++
- 1 file changed, 7 insertions(+)
+ tools/setup_helpers/extension.py | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
 
 Index: audio/tools/setup_helpers/extension.py
 ===================================================================
 --- audio.orig/tools/setup_helpers/extension.py
 +++ audio/tools/setup_helpers/extension.py
-@@ -141,6 +141,13 @@
+@@ -141,6 +141,16 @@
              f"-DUSE_OPENMP:BOOL={'ON' if _USE_OPENMP else 'OFF'}",
              f"-DUSE_FFMPEG:BOOL={'ON' if _USE_FFMPEG else 'OFF'}",
          ]
-+        if _USE_CUDA and platform.system() == "Linux":
-+            _arch = os.uname().machine
-+            cmake_args += [
-+                f"-DCMAKE_CUDA_COMPILER=nvcc",
-+                f"-DCMAKE_FIND_ROOT_PATH={os.environ.get('PREFIX', '')};{os.environ.get('BUILD_PREFIX', '')}/{_arch}-conda-linux-gnu/sysroot;{os.environ.get('PREFIX', '')}/targets/{_arch}-linux;{os.environ.get('BUILD_PREFIX', '')}/targets/{_arch}-linux",
-+            ]
++        if _USE_CUDA:
++            _prefix = os.environ.get('PREFIX', '')
++            _build_prefix = os.environ.get('BUILD_PREFIX', '')
++            _find_root = _prefix
++            if platform.system() == "Linux":
++                _arch = os.uname().machine
++                _find_root = f"{_prefix};{_build_prefix}/{_arch}-conda-linux-gnu/sysroot;{_prefix}/targets/{_arch}-linux;{_build_prefix}/targets/{_arch}-linux"
++                cmake_args += [f"-DCMAKE_CUDA_COMPILER=nvcc"]
++            cmake_args += [f"-DCMAKE_FIND_ROOT_PATH={_find_root}"]
 +
          build_args = ["--target", "install"]
          # Pass CUDA architecture to cmake

--- a/recipe/patches/0001-add-cuda-cmake-vars.patch
+++ b/recipe/patches/0001-add-cuda-cmake-vars.patch
@@ -1,22 +1,27 @@
 From: Daniel Petry <dpetry@anaconda.com>
-Subject: [PATCH 4/5] Add CMake variables to find CUDA
+Subject: [PATCH] Add CMAKE_FIND_ROOT_PATH for conda CUDA sysroot (Linux only)
+
+Adds CMAKE_FIND_ROOT_PATH so CMake can find CUDA libraries in the
+conda sysroot on Linux. Guarded with platform check to avoid applying
+Linux-specific paths on Windows CUDA builds.
 
 ---
- tools/setup_helpers/extension.py | 4 ++++
- 1 file changed, 4 insertions(+)
+ tools/setup_helpers/extension.py | 7 +++++++
+ 1 file changed, 7 insertions(+)
 
 Index: audio/tools/setup_helpers/extension.py
 ===================================================================
---- audio.orig/tools/setup_helpers/extension.py	2025-05-07 13:58:10.152255010 -0500
-+++ audio/tools/setup_helpers/extension.py	2025-05-07 14:00:45.638695581 -0500
-@@ -141,6 +141,12 @@
+--- audio.orig/tools/setup_helpers/extension.py
++++ audio/tools/setup_helpers/extension.py
+@@ -141,6 +141,13 @@
              f"-DUSE_OPENMP:BOOL={'ON' if _USE_OPENMP else 'OFF'}",
              f"-DUSE_FFMPEG:BOOL={'ON' if _USE_FFMPEG else 'OFF'}",
          ]
-+        if _USE_CUDA:
++        if _USE_CUDA and platform.system() == "Linux":
++            _arch = os.uname().machine
 +            cmake_args += [
 +                f"-DCMAKE_CUDA_COMPILER=nvcc",
-+                f"-DCMAKE_FIND_ROOT_PATH={os.environ.get('PREFIX', '')};{os.environ.get('BUILD_PREFIX', '')}/x86_64-conda-linux-gnu/sysroot;{os.environ.get('PREFIX', '')}/targets/x86_64-linux;{os.environ.get('BUILD_PREFIX', '')}/targets/x86_64-linux",
++                f"-DCMAKE_FIND_ROOT_PATH={os.environ.get('PREFIX', '')};{os.environ.get('BUILD_PREFIX', '')}/{_arch}-conda-linux-gnu/sysroot;{os.environ.get('PREFIX', '')}/targets/{_arch}-linux;{os.environ.get('BUILD_PREFIX', '')}/targets/{_arch}-linux",
 +            ]
 +
          build_args = ["--target", "install"]


### PR DESCRIPTION
torchaudio 2.8.0

**Destination channel:** defaults

### Links

- [PKG-13295](https://anaconda.atlassian.net/browse/PKG-13295)
- [Upstream repository](https://github.com/pytorch/audio)
- [Upstream changelog/diff](https://github.com/pytorch/audio/compare/v2.7.0...v2.8.0)
- Relevant dependency PRs:

### Explanation of changes:

- Update version from 2.7.0 to 2.8.0 (requires pytorch 2.8)
- Keep py>313 skip (pytorch 2.8 has no py314 builds)
- Maintenance mode release: features deprecated in 2.8 (see [upstream message](https://github.com/pytorch/audio/issues/3902))

[PKG-13295]: https://anaconda.atlassian.net/browse/PKG-13295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ