### PR TITLE
Update torchaudio to 2.9.1 (pytorch 2.9.1)

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,7 +18,12 @@ fi
 
 # CUDA specific settings
 if [[ "${gpu_variant}" == "cuda" ]]; then
-    export TORCH_CUDA_ARCH_LIST="5.0;6.0;6.1;7.0;7.5;8.0;8.6;8.9;9.0+PTX"
+    if [[ ${cuda_compiler_version} == 12.[0-6] ]]; then
+        export TORCH_CUDA_ARCH_LIST="5.0;6.0;6.1;7.0;7.5;8.0;8.6;8.9;9.0+PTX"
+    else
+        # CUDA 12.8+/13.x: cap at 10.0+PTX (pytorch 2.9.1 doesn't support arch 10.1)
+        export TORCH_CUDA_ARCH_LIST="5.0;6.0;6.1;7.0;7.5;8.0;8.6;8.9;9.0;10.0+PTX"
+    fi
     export USE_CUDA=1
     export BUILD_CUDA_CTC_DECODER=1
 fi

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,5 +1,6 @@
-cuda_compiler_version:       # [((linux or win) and x86_64)]
-  - 12.8                     # [((linux or win) and x86_64)]
+cuda_compiler_version:       # [(linux or win)]
+  - 12.8                     # [((linux and x86_64) or win)]
+  - 13.0                     # [(linux or win)]
 gpu_variant:
   - cpu
-  - cuda                     # [((linux or win) and x86_64)]
+  - cuda                     # [(linux or win)]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "torchaudio" %}
-{% set version = "2.8.0" %}
+{% set version = "2.9.1" %}
 {% set run_all_unittests = False %}
 # Torchaudio and PyTorch are tightly coupled in terms of versions.
 # check the [releases page](https://github.com/pytorch/audio/releases) for compatibility.
@@ -18,15 +18,14 @@ package:
 
 source:
   url: https://github.com/pytorch/audio/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 8809e4b0fa1635a89d5b05fe8e6e1db79fc0cc2052474ef6e76e349755827c12
+  sha256: 590492c90552959b3df6f601eb733135064bf2d9e53c516adcf6845a4e545662
   patches:
     - patches/0001-add-cuda-cmake-vars.patch
     - patches/0002-replace-FLT_MAX-for-compatibility-with-newer-cudatoo.patch
 
 build:
   number: {{ build }}
-  # py314 support in 2.9.0
-  skip: true                        # [py>313]
+  # py314 supported in 2.9.x
   string: cpu_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                # [gpu_variant == "cpu"]
   string: cuda{{ cuda_compiler_version | replace('.', '') }}py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [gpu_variant == "cuda"]
   missing_dso_whitelist:
@@ -62,8 +61,7 @@ requirements:
     - pip
     - pytorch ={{ version }}.*=*{{ gpu_variant }}*
     - libtorch ={{ version }}.*=*{{ gpu_variant }}*
-    # pybind11 2.13 has py314 support
-    - pybind11 2.12
+    - pybind11 2.13.6
     - llvm-openmp                                 # [osx]
     - cuda-version {{ cuda_compiler_version }}    # [gpu_variant == "cuda"]
     - cuda-driver-dev                             # [linux and gpu_variant == "cuda"]
@@ -78,33 +76,22 @@ requirements:
     - pytorch ={{ version }}.*=*{{ gpu_variant }}*
     - __cuda                                      # [gpu_variant == "cuda"]
 
-# ignoring sox tests because sox is disabled
-{% set ignore_modules =                  " --ignore=test/torchaudio_unittest/backend/dispatcher/sox --ignore=test/torchaudio_unittest/backend/sox_io" %}
-# these tests hang on osx-64, probably resource exhaustion
-{% set ignore_modules = ignore_modules + " --ignore=test/torchaudio_unittest/datasets" %}  # [osx and x86_64]
-# and these are killed on win, probably same reason
+# v2.9.1 maintenance mode: backend and io modules removed upstream
+{% set ignore_modules = "" %}
+# these tests are killed on win, probably resource exhaustion
 {% set ignore_modules = ignore_modules + " --ignore=test/torchaudio_unittest/models" %}    # [win]
-# these tests import torchaudio.prototype which does not exist in main module
-{% set ignore_modules = ignore_modules + " --ignore=test/integration_tests/prototype --ignore=test/integration_tests/rnnt_pipeline_test.py" %}
 # test to skip because of missing flashlight-text
 {% set ignore_modules = ignore_modules + " --ignore=test/integration_tests/ctc_decoder_integration_test.py" %}
 # test to skip because of missing dependency deep-phonemizer
 {% set ignore_modules = ignore_modules + " --ignore=test/integration_tests/tacotron2_pipeline_test.py" %}
-# Tests to skip because of frame_offset not being accepted as argument of load() function. All load function implementation
-# seem to have a frame_offset parameter except for torchaudio/backend/_no_backend.py::load(), which should not be used since
-# ffmpeg is chosen as backend. More investigation would be necessary but this doesn't seem to be a problem with all other
-# occurrences of the load() function
-{% set ignore_modules = ignore_modules + " --ignore=test/torchaudio_unittest/datasets/tedlium_test.py" %}
-# stream writer tests fail on windows because another process locks the writing on the output directory (common problem on win)
-{% set ignore_modules = ignore_modules + " --ignore=test/torchaudio_unittest/io/stream_writer_test.py" %}  # [win]
+{% set ignore_modules = ignore_modules + " --ignore=test/integration_tests/rnnt_pipeline_test.py" %}
+{% set ignore_modules = ignore_modules + " --ignore=test/integration_tests/wav2vec2_pipeline_test.py" %}
 
 # We don't provide kaldi-io in our distro, so skip tests that test functionality that requires it
 {% set tests_to_skip = "kaldi or rnnt or test_unknown_subtype_warning" %}
 
 # skip due ARM w/ JIT kernal generation on aarch64 resulting in a failure on CI
 {% set tests_to_skip = tests_to_skip + " or test_lfilter_shape" %}  # [aarch64]
-
-{% set ignore_modules = ignore_modules + " --ignore=test/integration_tests/wav2vec2_pipeline_test.py" %}
 
 {% set integration_tests_to_skip = "_not_a_real_test" %}
 # RNNT is disabled
@@ -116,8 +103,8 @@ test:
     - test/torchaudio_unittest
   {% else %}
     # choosing a subset of tests to prevent resource exhaustion and still run a reasonable amount of unit tests
+    # v2.9.1: backend and io directories removed upstream (maintenance mode)
     - test/torchaudio_unittest/assets
-    - test/torchaudio_unittest/backend
     - test/torchaudio_unittest/common_utils
     - test/torchaudio_unittest/compliance
     - test/torchaudio_unittest/datasets/__init__.py
@@ -128,7 +115,6 @@ test:
     - test/torchaudio_unittest/functional/functional_impl.py
     - test/torchaudio_unittest/functional/autograd_impl.py
     - test/torchaudio_unittest/functional/torchscript_consistency_impl.py
-    - test/torchaudio_unittest/io
     - test/torchaudio_unittest/transforms/__init__.py
     - test/torchaudio_unittest/transforms/torchscript_consistency_impl.py
     - test/torchaudio_unittest/transforms/transforms_test.py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,7 +64,6 @@ requirements:
     - pybind11 2.13.6
     - llvm-openmp                                 # [osx]
     - cuda-version {{ cuda_compiler_version }}    # [gpu_variant == "cuda"]
-    - cuda-driver-dev                             # [linux and gpu_variant == "cuda"]
     - cuda-cudart-dev                             # [gpu_variant == "cuda"]
     - cuda-nvtx-dev                               # [gpu_variant == "cuda"]
     - cuda-nvml-dev                               # [gpu_variant == "cuda"]
@@ -74,7 +73,6 @@ requirements:
   run:
     - python
     - pytorch ={{ version }}.*=*{{ gpu_variant }}*
-    - __cuda                                      # [gpu_variant == "cuda"]
 
 # v2.9.1 maintenance mode: backend and io modules removed upstream
 {% set ignore_modules = "" %}

--- a/recipe/patches/0001-add-cuda-cmake-vars.patch
+++ b/recipe/patches/0001-add-cuda-cmake-vars.patch
@@ -5,17 +5,13 @@ Adds CMAKE_FIND_ROOT_PATH so CMake can find CUDA and torch libraries
 in the conda prefix. On Linux, also adds the conda sysroot paths.
 Uses os.uname().machine for architecture-aware paths on Linux.
 
-Upstream already handles CMAKE_CUDA_COMPILER and CUDA_TOOLKIT_ROOT_DIR
-natively (since v2.9.0), so CMAKE_CUDA_COMPILER=nvcc is only added
-on Linux where the upstream detection may not work with conda paths.
-
 ---
- tools/setup_helpers/extension.py | 10 ++++++++++
- 1 file changed, 10 insertions(+)
+ tools/setup_helpers/extension.py | 9 +++++++++
+ 1 file changed, 9 insertions(+)
 
 --- a/tools/setup_helpers/extension.py
 +++ b/tools/setup_helpers/extension.py
-@@ -111,6 +111,16 @@
+@@ -111,6 +111,15 @@
              f"-DUSE_OPENMP:BOOL={'ON' if _USE_OPENMP else 'OFF'}",
          ]
 +        if _USE_CUDA:
@@ -25,7 +21,6 @@ on Linux where the upstream detection may not work with conda paths.
 +            if platform.system() == "Linux":
 +                _arch = os.uname().machine
 +                _find_root = f"{_prefix};{_build_prefix}/{_arch}-conda-linux-gnu/sysroot;{_prefix}/targets/{_arch}-linux;{_build_prefix}/targets/{_arch}-linux"
-+                cmake_args += [f"-DCMAKE_CUDA_COMPILER=nvcc"]
 +            cmake_args += [f"-DCMAKE_FIND_ROOT_PATH={_find_root}"]
 +
          build_args = ["--target", "install"]

--- a/recipe/patches/0001-add-cuda-cmake-vars.patch
+++ b/recipe/patches/0001-add-cuda-cmake-vars.patch
@@ -5,17 +5,18 @@ Adds CMAKE_FIND_ROOT_PATH so CMake can find CUDA and torch libraries
 in the conda prefix. On Linux, also adds the conda sysroot paths.
 Uses os.uname().machine for architecture-aware paths on Linux.
 
+Upstream already handles CMAKE_CUDA_COMPILER and CUDA_TOOLKIT_ROOT_DIR
+natively (since v2.9.0), so CMAKE_CUDA_COMPILER=nvcc is only added
+on Linux where the upstream detection may not work with conda paths.
+
 ---
  tools/setup_helpers/extension.py | 10 ++++++++++
  1 file changed, 10 insertions(+)
 
-Index: audio/tools/setup_helpers/extension.py
-===================================================================
---- audio.orig/tools/setup_helpers/extension.py
-+++ audio/tools/setup_helpers/extension.py
-@@ -141,6 +141,16 @@
+--- a/tools/setup_helpers/extension.py
++++ b/tools/setup_helpers/extension.py
+@@ -111,6 +111,16 @@
              f"-DUSE_OPENMP:BOOL={'ON' if _USE_OPENMP else 'OFF'}",
-             f"-DUSE_FFMPEG:BOOL={'ON' if _USE_FFMPEG else 'OFF'}",
          ]
 +        if _USE_CUDA:
 +            _prefix = os.environ.get('PREFIX', '')


### PR DESCRIPTION
torchaudio 2.9.1

**Destination channel:** defaults

### Links

- [PKG-13296](https://anaconda.atlassian.net/browse/PKG-13296)
- [Upstream repository](https://github.com/pytorch/audio)
- [Upstream changelog/diff](https://github.com/pytorch/audio/compare/v2.8.0...v2.9.1)
- Relevant dependency PRs:

### Explanation of changes:

- Update version from 2.8.0 to 2.9.1 (requires pytorch 2.9.1)
- Enable aarch64 CUDA 13.0 (12.8 restricted to x86_64/win)
- Cap CUDA arch at 10.0+PTX (pytorch 2.9.1 doesn't support arch 10.1)
- Maintenance mode release: deprecated features removed in 2.9 (see [upstream message](https://github.com/pytorch/audio/issues/3902))

[PKG-13296]: https://anaconda.atlassian.net/browse/PKG-13296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ