### PR TITLE
Update torchaudio to 2.10.0 — CUDA 13.0 only

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,8 @@ build:
   number: {{ build }}
   # CUDA-only split PR — skip CPU builds (including osx dummy variant for Jinja2 rendering)
   skip: true  # [gpu_variant == "cpu"]
+  # pytorch 2.10 has no py3.14 build on pkgs/main yet — skip until rebuilt
+  skip: true  # [py==314]
   string: cpu_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                # [gpu_variant == "cpu"]
   string: cuda{{ cuda_compiler_version | replace('.', '') }}py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [gpu_variant == "cuda"]
   missing_dso_whitelist:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "torchaudio" %}
-{% set version = "2.9.1" %}
+{% set version = "2.10.0" %}
 {% set run_all_unittests = False %}
 # Torchaudio and PyTorch are tightly coupled in terms of versions.
 # check the [releases page](https://github.com/pytorch/audio/releases) for compatibility.
@@ -18,7 +18,7 @@ package:
 
 source:
   url: https://github.com/pytorch/audio/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 590492c90552959b3df6f601eb733135064bf2d9e53c516adcf6845a4e545662
+  sha256: d0d0d9575025eb85150356a0b0de75b553484838006af17a62470b52d59845d1
   patches:
     - patches/0001-add-cuda-cmake-vars.patch
     - patches/0002-replace-FLT_MAX-for-compatibility-with-newer-cudatoo.patch


### PR DESCRIPTION
torchaudio 2.10.0 — CUDA 13.0 (3 of 3)

**Destination channel:** defaults

### Links

- [PKG-13671](https://anaconda.atlassian.net/browse/PKG-13671)
- [Upstream repository](https://github.com/pytorch/audio)
- [Upstream changelog/diff](https://github.com/pytorch/audio/compare/v2.9.1...v2.10.0)
- Related PRs (split due to PBP lambda disk space):
  - #18 (CPU)
  - #19 (CUDA 12.8)

### Explanation of changes:

- Bump version 2.9.1 → 2.10.0 (matched companion to pytorch 2.10)
- CUDA 13.0 variant only (all linux + win-64, incl aarch64)

[PKG-13671]: https://anaconda.atlassian.net/browse/PKG-13671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ