### PR TITLE
Rebuild torchaudio 2.10.0 — py3.14 only — CPU

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,8 +25,8 @@ source:
 
 build:
   number: {{ build }}
-  # pytorch 2.10 has no py3.14 build on pkgs/main yet — skip until rebuilt
-  skip: true  # [py==314]
+  # py3.14 rebuild — only build py3.14 (py3.10–3.13 already shipped at build_number 0)
+  skip: true  # [py<314]
   string: cpu_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                # [gpu_variant == "cpu"]
   string: cuda{{ cuda_compiler_version | replace('.', '') }}py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [gpu_variant == "cuda"]
   missing_dso_whitelist:


### PR DESCRIPTION
torchaudio 2.10.0

**Destination channel:** defaults

### Links

- [PKG-13211](https://anaconda.atlassian.net/browse/PKG-13211)
- [Upstream repository](https://github.com/pytorch/audio)
- [Upstream changelog/diff](https://github.com/pytorch/audio/releases/tag/v2.10.0)
- Relevant dependency PRs:
  - pytorch 2.10 py3.14: shipped to pkgs/main (2026-05)
  - Original py3.10–3.13 PRs: #18 (CPU), #19 (CUDA 12.8), #20 (CUDA 13.0)
  - CUDA 12.8 py3.14: #22
  - CUDA 13.0 py3.14: #23

### Explanation of changes:

- pytorch 2.10 py3.14 is now on pkgs/main; original PRs #18–20 shipped py3.10–3.13 only (blocked by missing pytorch py3.14 at release time)
- Flip `skip: true # [py==314]` → `skip: true # [py<314]` so this graph builds py3.14 only, leaving py3.10–3.13 artifacts at build_number 0 untouched
- Targets `main-cpu-py314` (dedicated landing branch) to avoid permanently tainting `main-cpu` with a `py<314` skip

[PKG-13211]: https://anaconda.atlassian.net/browse/PKG-13211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ