### PR TITLE
Rebuild torchaudio 2.10.0 -- py3.14 only

### DIFF
--- a/recipe/abs.yaml
+++ b/recipe/abs.yaml
@@ -1,0 +1,2 @@
+build_parameters:
+  - "--skip-existing"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -8,4 +8,11 @@ set BUILD_TORCHAUDIO_PYTHON_EXTENSION=ON
 :: Point the build system towards torch .lib files (needed for CUDA builds)
 set LIB=%PREFIX%\Lib\site-packages\torch\lib;%LIB%
 
+:: Point to build env's CUDA (nvcc is in build env, not host env)
+set CUDA_HOME=%BUILD_PREFIX%\Library
+set CUDA_PATH=%BUILD_PREFIX%\Library
+
+:: CUDA 12.8: cap at 10.0 (pytorch 2.10.0 doesn't support arch 10.1)
+set TORCH_CUDA_ARCH_LIST=5.0;6.0;6.1;7.0;7.5;8.0;8.6;8.9;9.0;10.0+PTX
+
 %PYTHON% -m pip install . -vv --no-deps --no-build-isolation

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,7 +18,8 @@ fi
 
 # CUDA specific settings
 if [[ "${gpu_variant}" == "cuda" ]]; then
-    export TORCH_CUDA_ARCH_LIST="5.0;6.0;6.1;7.0;7.5;8.0;8.6;8.9;9.0+PTX"
+    # CUDA 12.8: cap at 10.0 (pytorch 2.10.0 doesn't support arch 10.1)
+    export TORCH_CUDA_ARCH_LIST="5.0;6.0;6.1;7.0;7.5;8.0;8.6;8.9;9.0;10.0+PTX"
     export USE_CUDA=1
     export BUILD_CUDA_CTC_DECODER=1
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "torchaudio" %}
-{% set version = "2.8.0" %}
+{% set version = "2.10.0" %}
 {% set run_all_unittests = False %}
 # Torchaudio and PyTorch are tightly coupled in terms of versions.
 # check the [releases page](https://github.com/pytorch/audio/releases) for compatibility.
@@ -18,15 +18,13 @@ package:
 
 source:
   url: https://github.com/pytorch/audio/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 8809e4b0fa1635a89d5b05fe8e6e1db79fc0cc2052474ef6e76e349755827c12
+  sha256: d0d0d9575025eb85150356a0b0de75b553484838006af17a62470b52d59845d1
   patches:
     - patches/0001-add-cuda-cmake-vars.patch
     - patches/0002-replace-FLT_MAX-for-compatibility-with-newer-cudatoo.patch
 
 build:
   number: {{ build }}
-  # py314 support in 2.9.0
-  skip: true                        # [py>313]
   string: cpu_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                # [gpu_variant == "cpu"]
   string: cuda{{ cuda_compiler_version | replace('.', '') }}py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [gpu_variant == "cuda"]
   missing_dso_whitelist:
@@ -61,12 +59,11 @@ requirements:
     - wheel
     - pip
     - pytorch ={{ version }}.*=*{{ gpu_variant }}*
+    - __cuda                                      # [gpu_variant == "cuda"]
     - libtorch ={{ version }}.*=*{{ gpu_variant }}*
-    # pybind11 2.13 has py314 support
-    - pybind11 2.12
+    - pybind11 2.13.6
     - llvm-openmp                                 # [osx]
     - cuda-version {{ cuda_compiler_version }}    # [gpu_variant == "cuda"]
-    - cuda-driver-dev                             # [linux and gpu_variant == "cuda"]
     - cuda-cudart-dev                             # [gpu_variant == "cuda"]
     - cuda-nvtx-dev                               # [gpu_variant == "cuda"]
     - cuda-nvml-dev                               # [gpu_variant == "cuda"]
@@ -78,33 +75,29 @@ requirements:
     - pytorch ={{ version }}.*=*{{ gpu_variant }}*
     - __cuda                                      # [gpu_variant == "cuda"]
 
-# ignoring sox tests because sox is disabled
-{% set ignore_modules =                  " --ignore=test/torchaudio_unittest/backend/dispatcher/sox --ignore=test/torchaudio_unittest/backend/sox_io" %}
-# these tests hang on osx-64, probably resource exhaustion
-{% set ignore_modules = ignore_modules + " --ignore=test/torchaudio_unittest/datasets" %}  # [osx and x86_64]
-# and these are killed on win, probably same reason
+# v2.9.1 maintenance mode: backend and io modules removed upstream
+{% set ignore_modules = "" %}
+# these tests are killed on win, probably resource exhaustion
 {% set ignore_modules = ignore_modules + " --ignore=test/torchaudio_unittest/models" %}    # [win]
-# these tests import torchaudio.prototype which does not exist in main module
-{% set ignore_modules = ignore_modules + " --ignore=test/integration_tests/prototype --ignore=test/integration_tests/rnnt_pipeline_test.py" %}
 # test to skip because of missing flashlight-text
 {% set ignore_modules = ignore_modules + " --ignore=test/integration_tests/ctc_decoder_integration_test.py" %}
 # test to skip because of missing dependency deep-phonemizer
 {% set ignore_modules = ignore_modules + " --ignore=test/integration_tests/tacotron2_pipeline_test.py" %}
-# Tests to skip because of frame_offset not being accepted as argument of load() function. All load function implementation
-# seem to have a frame_offset parameter except for torchaudio/backend/_no_backend.py::load(), which should not be used since
-# ffmpeg is chosen as backend. More investigation would be necessary but this doesn't seem to be a problem with all other
-# occurrences of the load() function
+{% set ignore_modules = ignore_modules + " --ignore=test/integration_tests/rnnt_pipeline_test.py" %}
+{% set ignore_modules = ignore_modules + " --ignore=test/integration_tests/wav2vec2_pipeline_test.py" %}
+# These tests download large files from the internet, not suitable for CI
+{% set ignore_modules = ignore_modules + " --ignore=test/integration_tests/loudness_compliance_test.py" %}
+{% set ignore_modules = ignore_modules + " --ignore=test/integration_tests/source_separation_pipeline_test.py" %}
+{% set ignore_modules = ignore_modules + " --ignore=test/integration_tests/squim_pipeline_test.py" %}
+# tedlium tests require downloading dataset; wsj0mix tests require downloading data
 {% set ignore_modules = ignore_modules + " --ignore=test/torchaudio_unittest/datasets/tedlium_test.py" %}
-# stream writer tests fail on windows because another process locks the writing on the output directory (common problem on win)
-{% set ignore_modules = ignore_modules + " --ignore=test/torchaudio_unittest/io/stream_writer_test.py" %}  # [win]
+{% set ignore_modules = ignore_modules + " --ignore=test/torchaudio_unittest/example" %}
 
 # We don't provide kaldi-io in our distro, so skip tests that test functionality that requires it
 {% set tests_to_skip = "kaldi or rnnt or test_unknown_subtype_warning" %}
 
 # skip due ARM w/ JIT kernal generation on aarch64 resulting in a failure on CI
 {% set tests_to_skip = tests_to_skip + " or test_lfilter_shape" %}  # [aarch64]
-
-{% set ignore_modules = ignore_modules + " --ignore=test/integration_tests/wav2vec2_pipeline_test.py" %}
 
 {% set integration_tests_to_skip = "_not_a_real_test" %}
 # RNNT is disabled
@@ -116,8 +109,8 @@ test:
     - test/torchaudio_unittest
   {% else %}
     # choosing a subset of tests to prevent resource exhaustion and still run a reasonable amount of unit tests
+    # v2.9.1: backend and io directories removed upstream (maintenance mode)
     - test/torchaudio_unittest/assets
-    - test/torchaudio_unittest/backend
     - test/torchaudio_unittest/common_utils
     - test/torchaudio_unittest/compliance
     - test/torchaudio_unittest/datasets/__init__.py
@@ -128,7 +121,6 @@ test:
     - test/torchaudio_unittest/functional/functional_impl.py
     - test/torchaudio_unittest/functional/autograd_impl.py
     - test/torchaudio_unittest/functional/torchscript_consistency_impl.py
-    - test/torchaudio_unittest/io
     - test/torchaudio_unittest/transforms/__init__.py
     - test/torchaudio_unittest/transforms/torchscript_consistency_impl.py
     - test/torchaudio_unittest/transforms/transforms_test.py
@@ -140,7 +132,6 @@ test:
     - test/torchaudio_unittest/__init__.py
   {% endif %}
     - test/smoke_test
-    - test/integration_tests
     - examples
   imports:
     - torchaudio
@@ -149,7 +140,8 @@ test:
   commands:
     - pip check
     - python test/smoke_test/smoke_test.py
-    - pytest -v {{ ignore_modules }} -k "not ({{ integration_tests_to_skip }})" test/integration_tests
+    # v2.9.1: all remaining integration tests download from internet, skip entirely
+    # - pytest -v {{ ignore_modules }} -k "not ({{ integration_tests_to_skip }})" test/integration_tests
   {% if run_all_unittests %}
     # to run the tests that require hubert, `dataset` is necessary (currently missing on main)
     - export PYTHONPATH=$PWD/examples/hubert:$PYTHONPATH  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,9 @@ source:
 
 build:
   number: {{ build }}
+  # Temporary: py3.14-only rebuild — py3.10–3.13 already shipped at build_number 0.
+  # Remove this skip when rebuilding all Python versions (e.g. next version bump).
+  skip: true  # [py<314]
   string: cpu_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                # [gpu_variant == "cpu"]
   string: cuda{{ cuda_compiler_version | replace('.', '') }}py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [gpu_variant == "cuda"]
   missing_dso_whitelist:

--- a/recipe/patches/0001-add-cuda-cmake-vars.patch
+++ b/recipe/patches/0001-add-cuda-cmake-vars.patch
@@ -6,16 +6,13 @@ in the conda prefix. On Linux, also adds the conda sysroot paths.
 Uses os.uname().machine for architecture-aware paths on Linux.
 
 ---
- tools/setup_helpers/extension.py | 10 ++++++++++
- 1 file changed, 10 insertions(+)
+ tools/setup_helpers/extension.py | 9 +++++++++
+ 1 file changed, 9 insertions(+)
 
-Index: audio/tools/setup_helpers/extension.py
-===================================================================
---- audio.orig/tools/setup_helpers/extension.py
-+++ audio/tools/setup_helpers/extension.py
-@@ -141,6 +141,16 @@
+--- a/tools/setup_helpers/extension.py
++++ b/tools/setup_helpers/extension.py
+@@ -111,6 +111,15 @@
              f"-DUSE_OPENMP:BOOL={'ON' if _USE_OPENMP else 'OFF'}",
-             f"-DUSE_FFMPEG:BOOL={'ON' if _USE_FFMPEG else 'OFF'}",
          ]
 +        if _USE_CUDA:
 +            _prefix = os.environ.get('PREFIX', '')
@@ -24,7 +21,6 @@ Index: audio/tools/setup_helpers/extension.py
 +            if platform.system() == "Linux":
 +                _arch = os.uname().machine
 +                _find_root = f"{_prefix};{_build_prefix}/{_arch}-conda-linux-gnu/sysroot;{_prefix}/targets/{_arch}-linux;{_build_prefix}/targets/{_arch}-linux"
-+                cmake_args += [f"-DCMAKE_CUDA_COMPILER=nvcc"]
 +            cmake_args += [f"-DCMAKE_FIND_ROOT_PATH={_find_root}"]
 +
          build_args = ["--target", "install"]


### PR DESCRIPTION
torchaudio 2.10.0

**Destination channel:** defaults

### Links

- [PKG-13211](https://anaconda.atlassian.net/browse/PKG-13211)
- [Upstream repository](https://github.com/pytorch/audio)
- [Upstream changelog/diff](https://github.com/pytorch/audio/releases/tag/v2.10.0)
- Relevant dependency PRs:
  - pytorch 2.10 py3.14: shipped to pkgs/main (2026-05)
  - Original py3.10-3.13 PRs: #18 (CPU), #19 (CUDA 12.8), #20 (CUDA 13.0)

### Explanation of changes:

- pytorch 2.10 py3.14 is now on pkgs/main; original PRs #18-20 shipped py3.10-3.13 only (blocked by missing pytorch py3.14 at release time)
- abs.yaml sets --skip-existing so PBP skips py3.10-3.13 artifacts already at build_number 0 and only builds py3.14
- Combined CBC (cpu + cuda12.8) -- single PR targeting main per Charles Bousseau feedback; py3.14-only matrix is small enough to fit in one PBP graph without /tmp disk pressure
- Note: cuda13.0 py3.14 (linux-aarch64) not covered -- main CBC still uses cuda12.8; will be addressed in the next version update

[PKG-13211]: https://anaconda.atlassian.net/browse/PKG-13211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ