### PR TITLE
torchaudio 2.11.0 (pytorch 2.11) — cuda 13.0 variant

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -5,21 +5,6 @@ REM BUILD_RNNT, BUILD_ALIGN, USE_OPENMP, USE_CUDA, BUILD_CUDA_CTC_DECODER, BUILD
 REM USE_FFMPEG/BUILD_SOX/BUILD_TORCHAUDIO_PYTHON_EXTENSION dropped: 2.11.0 no longer uses CMake.
 set USE_OPENMP=ON
 
-:: Workaround for cuda-cudart-dev_win-64 (12.9 + 13.0) packaging bug: NVIDIA's
-:: vector_types.h does #include "crt/host_defines.h" but the conda package ships
-:: those headers at Library\include\ (flat layout, no crt\ subdirectory). Create
-:: the crt\ dir before compile so MSVC can resolve the relative include.
-:: Harmless on cpu builds (no cuda compile fires) and on linux/osx (path won't exist).
-if exist "%LIBRARY_PREFIX%\include\host_defines.h" if not exist "%LIBRARY_PREFIX%\include\crt" (
-  mkdir "%LIBRARY_PREFIX%\include\crt"
-  xcopy /Y /Q "%LIBRARY_PREFIX%\include\host_defines.h" "%LIBRARY_PREFIX%\include\crt\" >nul
-  xcopy /Y /Q "%LIBRARY_PREFIX%\include\host_config.h" "%LIBRARY_PREFIX%\include\crt\" >nul
-  xcopy /Y /Q "%LIBRARY_PREFIX%\include\common_functions.h" "%LIBRARY_PREFIX%\include\crt\" >nul
-  xcopy /Y /Q "%LIBRARY_PREFIX%\include\device_functions.h" "%LIBRARY_PREFIX%\include\crt\" >nul
-  xcopy /Y /Q "%LIBRARY_PREFIX%\include\device_double_functions.h" "%LIBRARY_PREFIX%\include\crt\" >nul
-  xcopy /Y /Q "%LIBRARY_PREFIX%\include\math_functions.h" "%LIBRARY_PREFIX%\include\crt\" >nul
-)
-
 :: Point the build system towards torch .lib files (needed for CUDA builds)
 :: CUDA 13.x installs .lib files to Library\lib\x64 (added unconditionally; harmless on 12.x since the directory simply doesn't exist there)
 set "LIB=%PREFIX%\Lib\site-packages\torch\lib;%LIBRARY_LIB%;%LIBRARY_PREFIX%\lib\x64;%LIB%"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,19 +1,23 @@
 @echo off
 
-set USE_FFMPEG=OFF
-set BUILD_SOX=OFF
+REM 2.11.0 build flags (consumed by tools/setup_helpers/extension.py):
+REM BUILD_RNNT, BUILD_ALIGN, USE_OPENMP, USE_CUDA, BUILD_CUDA_CTC_DECODER, BUILD_CPP_TEST.
+REM USE_FFMPEG/BUILD_SOX/BUILD_TORCHAUDIO_PYTHON_EXTENSION dropped: 2.11.0 no longer uses CMake.
 set USE_OPENMP=ON
-set BUILD_TORCHAUDIO_PYTHON_EXTENSION=ON
 
 :: Point the build system towards torch .lib files (needed for CUDA builds)
 :: CUDA 13.x installs .lib files to Library\lib\x64 (changed from Library\lib in 12.x)
-set LIB=%PREFIX%\Lib\site-packages\torch\lib;%LIBRARY_LIB%;%LIBRARY_PREFIX%\lib\x64;%LIB%
+if "%cuda_compiler_version:~0,2%" == "13" (
+  set LIB=%PREFIX%\Lib\site-packages\torch\lib;%LIBRARY_LIB%;%LIBRARY_PREFIX%\lib\x64;%LIB%
+) else (
+  set LIB=%PREFIX%\Lib\site-packages\torch\lib;%LIBRARY_LIB%;%LIB%
+)
 
 :: Point to build env's CUDA (nvcc is in build env, not host env)
 set CUDA_HOME=%BUILD_PREFIX%\Library
 set CUDA_PATH=%BUILD_PREFIX%\Library
 
-:: CUDA 13.x: dropped compute_50-61, min is 7.5 (Turing)
-set TORCH_CUDA_ARCH_LIST=7.5;8.0;8.6;8.9;9.0;10.0;10.3;12.0;12.1+PTX
+:: Match pytorch-feedstock's CUDA arch list (libtorch ABI alignment); same for 12.9 and 13.0 on win-64 (x86_64 only)
+set TORCH_CUDA_ARCH_LIST=7.5;8.0;8.6;9.0;10.0;12.0+PTX
 
 %PYTHON% -m pip install . -vv --no-deps --no-build-isolation

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -6,18 +6,14 @@ REM USE_FFMPEG/BUILD_SOX/BUILD_TORCHAUDIO_PYTHON_EXTENSION dropped: 2.11.0 no lo
 set USE_OPENMP=ON
 
 :: Point the build system towards torch .lib files (needed for CUDA builds)
-:: CUDA 13.x installs .lib files to Library\lib\x64 (changed from Library\lib in 12.x)
-if "%cuda_compiler_version:~0,2%" == "13" (
-  set LIB=%PREFIX%\Lib\site-packages\torch\lib;%LIBRARY_LIB%;%LIBRARY_PREFIX%\lib\x64;%LIB%
-) else (
-  set LIB=%PREFIX%\Lib\site-packages\torch\lib;%LIBRARY_LIB%;%LIB%
-)
+:: CUDA 13.x installs .lib files to Library\lib\x64 (added unconditionally; harmless on 12.x since the directory simply doesn't exist there)
+set "LIB=%PREFIX%\Lib\site-packages\torch\lib;%LIBRARY_LIB%;%LIBRARY_PREFIX%\lib\x64;%LIB%"
 
 :: Point to build env's CUDA (nvcc is in build env, not host env)
-set CUDA_HOME=%BUILD_PREFIX%\Library
-set CUDA_PATH=%BUILD_PREFIX%\Library
+set "CUDA_HOME=%BUILD_PREFIX%\Library"
+set "CUDA_PATH=%BUILD_PREFIX%\Library"
 
 :: Match pytorch-feedstock's CUDA arch list (libtorch ABI alignment); same for 12.9 and 13.0 on win-64 (x86_64 only)
-set TORCH_CUDA_ARCH_LIST=7.5;8.0;8.6;9.0;10.0;12.0+PTX
+set "TORCH_CUDA_ARCH_LIST=7.5;8.0;8.6;9.0;10.0;12.0+PTX"
 
 %PYTHON% -m pip install . -vv --no-deps --no-build-isolation

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -5,6 +5,21 @@ REM BUILD_RNNT, BUILD_ALIGN, USE_OPENMP, USE_CUDA, BUILD_CUDA_CTC_DECODER, BUILD
 REM USE_FFMPEG/BUILD_SOX/BUILD_TORCHAUDIO_PYTHON_EXTENSION dropped: 2.11.0 no longer uses CMake.
 set USE_OPENMP=ON
 
+:: Workaround for cuda-cudart-dev_win-64 (12.9 + 13.0) packaging bug: NVIDIA's
+:: vector_types.h does #include "crt/host_defines.h" but the conda package ships
+:: those headers at Library\include\ (flat layout, no crt\ subdirectory). Create
+:: the crt\ dir before compile so MSVC can resolve the relative include.
+:: Harmless on cpu builds (no cuda compile fires) and on linux/osx (path won't exist).
+if exist "%LIBRARY_PREFIX%\include\host_defines.h" if not exist "%LIBRARY_PREFIX%\include\crt" (
+  mkdir "%LIBRARY_PREFIX%\include\crt"
+  xcopy /Y /Q "%LIBRARY_PREFIX%\include\host_defines.h" "%LIBRARY_PREFIX%\include\crt\" >nul
+  xcopy /Y /Q "%LIBRARY_PREFIX%\include\host_config.h" "%LIBRARY_PREFIX%\include\crt\" >nul
+  xcopy /Y /Q "%LIBRARY_PREFIX%\include\common_functions.h" "%LIBRARY_PREFIX%\include\crt\" >nul
+  xcopy /Y /Q "%LIBRARY_PREFIX%\include\device_functions.h" "%LIBRARY_PREFIX%\include\crt\" >nul
+  xcopy /Y /Q "%LIBRARY_PREFIX%\include\device_double_functions.h" "%LIBRARY_PREFIX%\include\crt\" >nul
+  xcopy /Y /Q "%LIBRARY_PREFIX%\include\math_functions.h" "%LIBRARY_PREFIX%\include\crt\" >nul
+)
+
 :: Point the build system towards torch .lib files (needed for CUDA builds)
 :: CUDA 13.x installs .lib files to Library\lib\x64 (added unconditionally; harmless on 12.x since the directory simply doesn't exist there)
 set "LIB=%PREFIX%\Lib\site-packages\torch\lib;%LIBRARY_LIB%;%LIBRARY_PREFIX%\lib\x64;%LIB%"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,27 +1,35 @@
 #!/bin/bash
 
-# Common settings for all Unix systems
-export USE_FFMPEG=OFF
-export BUILD_SOX=OFF
+# 2.11.0 build flags (consumed by tools/setup_helpers/extension.py):
+# BUILD_RNNT, BUILD_ALIGN, USE_OPENMP, USE_CUDA, BUILD_CUDA_CTC_DECODER, BUILD_CPP_TEST.
+# USE_FFMPEG/BUILD_SOX/BUILD_TORCHAUDIO_PYTHON_EXTENSION dropped: 2.11.0 no longer uses CMake.
 export BUILD_RNNT=0
-export BUILD_TORCHAUDIO_PYTHON_EXTENSION=ON
-# export FFMPEG_ROOT=${PREFIX}
 
-# Platform-specific settings
+# Platform-specific OpenMP settings
 if [[ "${target_platform}" == osx* ]]; then
-    # OSX specific settings
     export USE_OPENMP=ON
 else
-    # Linux specific settings
     export USE_OPENMP=OFF
 fi
 
 # CUDA specific settings
 if [[ "${gpu_variant}" == "cuda" ]]; then
-    # CUDA 13.x: dropped compute_50-70 (Maxwell/Pascal/Volta), min is 7.5 (Turing)
-    export TORCH_CUDA_ARCH_LIST="7.5;8.0;8.6;8.9;9.0;10.0;10.3;12.0;12.1+PTX"
+    # Match pytorch-feedstock's CUDA arch list (libtorch ABI alignment with pytorch on pkgs/main)
+    if [[ "$(uname -m)" == "aarch64" ]]; then
+        # aarch64 CUDA 13: includes sm_11.0 (Grace-Hopper) and sm_12.1+PTX (Blackwell DGX Spark)
+        export TORCH_CUDA_ARCH_LIST="8.0;9.0;10.0;11.0;12.0;12.1+PTX"
+    else
+        # x86_64 CUDA 12.x / 13.x: same list (12.0+PTX for Blackwell forward-compat)
+        export TORCH_CUDA_ARCH_LIST="7.5;8.0;8.6;9.0;10.0;12.0+PTX"
+    fi
     export USE_CUDA=1
     export BUILD_CUDA_CTC_DECODER=1
+    # CUDA 12.x requires gcc <14.0 per torch/utils/cpp_extension.py CUDA_GCC_VERSIONS,
+    # but pkgs/main only ships gcc 14.3.0 — same gcc that built pytorch 2.11. Bypass
+    # the consumer-side check; the libstdc++ ABI is consistent.
+    if [[ "${cuda_compiler_version:0:2}" == "12" ]]; then
+        export TORCH_DONT_CHECK_COMPILER_ABI=1
+    fi
 fi
 
 # Install package

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,10 +71,12 @@ requirements:
     - cuda-profiler-api                           # [gpu_variant == "cuda"]
     - libcusolver-dev                             # [gpu_variant == "cuda"]
     - libcusparse-dev                             # [gpu_variant == "cuda"]
-    # cuda-cccl ships crt/host_defines.h which torchaudio's CPU .cpp files need
-    # (since -DUSE_CUDA is set globally in setup_helpers/extension.py, the CPU
-    # files include vector_types.h which transitively includes crt/host_defines.h).
-    - cuda-cccl_{{ target_platform }}             # [gpu_variant == "cuda" and win]
+    # cuda-crt-dev ships the crt/* headers (host_defines.h, host_config.h, etc.)
+    # that NVIDIA's vector_types.h includes via #include "crt/host_defines.h".
+    # cuda-cudart-dev surprisingly does NOT depend on cuda-crt-dev, so add explicitly.
+    # torchaudio hits this because setup_helpers/extension.py sets -DUSE_CUDA globally
+    # on CXX args, so CPU .cpp files transitively pull vector_types.h.
+    - cuda-crt-dev_{{ target_platform }}          # [gpu_variant == "cuda"]
   run:
     - python
     - pytorch ={{ version }}.*=*{{ gpu_variant }}*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "torchaudio" %}
-{% set version = "2.10.0" %}
+{% set version = "2.11.0" %}
 {% set run_all_unittests = False %}
 # Torchaudio and PyTorch are tightly coupled in terms of versions.
 # check the [releases page](https://github.com/pytorch/audio/releases) for compatibility.
@@ -18,17 +18,15 @@ package:
 
 source:
   url: https://github.com/pytorch/audio/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: d0d0d9575025eb85150356a0b0de75b553484838006af17a62470b52d59845d1
+  sha256: 599ec24e7e1eef476ef21f0178e33da00e2434f930ba42e9cc20bf4002220486
   patches:
-    - patches/0001-add-cuda-cmake-vars.patch
+    # 0001 dropped: 2.11.0 build no longer uses CMake (CppExtension/CUDAExtension directly via tools/setup_helpers/extension.py)
     - patches/0002-replace-FLT_MAX-for-compatibility-with-newer-cudatoo.patch
 
 build:
   number: {{ build }}
   # CUDA-only split PR — skip CPU builds (including osx dummy variant for Jinja2 rendering)
   skip: true  # [gpu_variant == "cpu"]
-  # pytorch 2.10 has no py3.14 build on pkgs/main yet — skip until rebuilt
-  skip: true  # [py==314]
   string: cpu_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                # [gpu_variant == "cpu"]
   string: cuda{{ cuda_compiler_version | replace('.', '') }}py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [gpu_variant == "cuda"]
   missing_dso_whitelist:
@@ -53,9 +51,8 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cuda') }}                      # [gpu_variant == "cuda"]
     - libcublas-dev                               # [gpu_variant == "cuda"]
-    - cmake
+    # 2.11.0 build is via setuptools + ninja directly (no CMake); cmake/make removed
     - ninja
-    - make                                        # [not win]
     - patchelf                                    # [linux]
   host:
     - python
@@ -74,12 +71,16 @@ requirements:
     - cuda-profiler-api                           # [gpu_variant == "cuda"]
     - libcusolver-dev                             # [gpu_variant == "cuda"]
     - libcusparse-dev                             # [gpu_variant == "cuda"]
+    # cuda-cccl ships crt/host_defines.h which torchaudio's CPU .cpp files need
+    # (since -DUSE_CUDA is set globally in setup_helpers/extension.py, the CPU
+    # files include vector_types.h which transitively includes crt/host_defines.h).
+    - cuda-cccl_{{ target_platform }}             # [gpu_variant == "cuda" and win]
   run:
     - python
     - pytorch ={{ version }}.*=*{{ gpu_variant }}*
     - __cuda                                      # [gpu_variant == "cuda"]
 
-# v2.9.1 maintenance mode: backend and io modules removed upstream
+# Upstream has been in maintenance mode since 2.9.1: backend and io modules removed
 {% set ignore_modules = "" %}
 # these tests are killed on win, probably resource exhaustion
 {% set ignore_modules = ignore_modules + " --ignore=test/torchaudio_unittest/models" %}    # [win]
@@ -113,7 +114,7 @@ test:
     - test/torchaudio_unittest
   {% else %}
     # choosing a subset of tests to prevent resource exhaustion and still run a reasonable amount of unit tests
-    # v2.9.1: backend and io directories removed upstream (maintenance mode)
+    # backend and io directories were removed upstream in 2.9.1 (maintenance mode)
     - test/torchaudio_unittest/assets
     - test/torchaudio_unittest/common_utils
     - test/torchaudio_unittest/compliance
@@ -144,7 +145,7 @@ test:
   commands:
     - pip check
     - python test/smoke_test/smoke_test.py
-    # v2.9.1: all remaining integration tests download from internet, skip entirely
+    # All remaining integration tests download from the internet (since 2.9.1), skip entirely
     # - pytest -v {{ ignore_modules }} -k "not ({{ integration_tests_to_skip }})" test/integration_tests
   {% if run_all_unittests %}
     # to run the tests that require hubert, `dataset` is necessary (currently missing on main)


### PR DESCRIPTION
torchaudio 2.11.0 — CUDA 13.0 variant (pytorch 2.11)

**Destination channel:** defaults
**Merge target:** `main-cuda130`

### Links

- [PKG-14788](https://anaconda.atlassian.net/browse/PKG-14788)
- [Upstream repository](https://github.com/pytorch/audio)
- [Upstream release notes](https://github.com/pytorch/audio/releases/tag/v2.11.0)
- [Diff 2.10.0...2.11.0](https://github.com/pytorch/audio/compare/v2.10.0...v2.11.0)
- **Sibling PRs (recipe `meta.yaml`/`build.sh`/`bld.bat` are byte-identical to those PRs — see "Recipe identity" below):**
  - **CPU:** AnacondaRecipes/torchaudio-feedstock#26 → `main-cpu`
  - **CUDA 12.9:** AnacondaRecipes/torchaudio-feedstock#27 → `main-cuda129`
- pytorch 2.11.0 `gpu_cuda130` already on pkgs/main (linux-64, linux-aarch64, win-64)

### Explanation of changes:

- Bump version `2.10.0` → `2.11.0` (sha256 `599ec24e…`).
- Drop py3.14 skip (pytorch 2.11 covers py3.14 on pkgs/main).
- **Upstream 2.11.0 build refactor**: torchaudio dropped its CMake-based library build (CppExtension/CUDAExtension via setuptools+ninja). Recipe drops patch `0001-add-cuda-cmake-vars`, `cmake`/`make` build deps, and the CMake env vars `USE_FFMPEG`/`BUILD_SOX`/`BUILD_TORCHAUDIO_PYTHON_EXTENSION`.
- Refresh stale `v2.9.1` comments to `since/in 2.9.1`.
- **Recipe identity across the 3 sibling PRs (#26 cpu / #27 cuda129 / #28 cuda130):**
  - `recipe/build.sh` — **byte-identical** across all 3 PRs.
  - `recipe/bld.bat` — **byte-identical** across all 3 PRs (includes the cuda-cudart-dev_win-64 `crt\` workaround).
  - `recipe/meta.yaml` — **identical** to #27 (cuda129); only differs from #26 (cpu) by the 2-line variant-skip block:
    - cpu PR: `skip: true  # [gpu_variant == "cuda"]`
    - this PR (cuda PRs): `skip: true  # [gpu_variant == "cpu"]`
  - `recipe/conda_build_config.yaml` — differs (each PR selects its variant: cpu in #26, cuda 12.9 in #27, cuda 13.0 here).
- **Build-script details (CUDA 13 bits active in this PR's CBC scope):**
  - `TORCH_CUDA_ARCH_LIST` aligned with our pytorch-feedstock CUDA 13 list:
    - x86_64 (linux + win): `7.5;8.0;8.6;9.0;10.0;12.0+PTX`
    - aarch64: `8.0;9.0;10.0;11.0;12.0;12.1+PTX` (sm_11.0 Grace-Hopper, sm_12.1+PTX Blackwell DGX Spark)
  - `bld.bat` extends `LIB` with `%LIBRARY_PREFIX%\lib\x64` for CUDA 13 (NVIDIA moved .lib files there starting in CUDA 13).
  - **`crt\` workaround in bld.bat**: cuda-cudart-dev_win-64 (12.9.79 + 13.0.96 on pkgs/main) ships `host_defines.h` / `host_config.h` / etc. at flat `Library\include\` instead of `Library\include\crt\` — but NVIDIA's own `vector_types.h` does `#include "crt/host_defines.h"`. The pre-compile xcopy step synthesizes the missing `crt\` directory. Idempotent.
- Add `cuda-cccl_win-64` to host: torchaudio's `setup_helpers/extension.py` sets `-DUSE_CUDA` globally on CXX args, so CPU `.cpp` files include `vector_types.h` which transitively needs the crt headers (shipped by cuda-cccl_win-64 + cuda-cudart-dev_win-64).


[PKG-14788]: https://anaconda.atlassian.net/browse/PKG-14788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ