### PR TITLE
PKG-14949: rebuild torchaudio 2.11.0 (CPU/MPS) against pybind11 3.0.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 # Torchaudio and PyTorch are tightly coupled in terms of versions.
 # check the [releases page](https://github.com/pytorch/audio/releases) for compatibility.
 
-{% set build = 0 %}
+{% set build = 1 %}
 # Use a higher build number for the GPU variants, to ensure that they're
 # preferred by conda's solver, and they're preferentially
 # installed where the platform supports it.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,7 +62,12 @@ requirements:
     - pytorch ={{ version }}.*=*{{ gpu_variant }}*
     - __cuda                                      # [gpu_variant == "cuda"]
     - libtorch ={{ version }}.*=*{{ gpu_variant }}*
-    - pybind11 2.13.6
+    # pybind11 itself is not needed: upstream uses torch.utils.cpp_extension
+    # which bundles pybind11 headers via the libtorch/pytorch deps above.
+    # pybind11-abi propagates the ABI-version pin (==11) via run_export so
+    # the resulting torchaudio artifact declares the correct ABI for
+    # cross-module C++ type exchange with pytorch.
+    - pybind11-abi
     - llvm-openmp                                 # [osx]
     - cuda-version {{ cuda_compiler_version }}    # [gpu_variant == "cuda"]
     - cuda-cudart-dev                             # [gpu_variant == "cuda"]


### PR DESCRIPTION
torchaudio 2.11.0 (CPU/MPS branch)

**Destination channel:** Defaults
**Base branch:** `main-cpu` (the CPU/MPS release track for 2.11.0). CUDA variants (main-cuda129, main-cuda130) are not yet on pkgs/main — they will get separate rebuild PRs after their initial release.

### Links

- [PKG-14949](https://anaconda.atlassian.net/browse/PKG-14949)
- [PKG-13552](https://anaconda.atlassian.net/browse/PKG-13552) (parent epic)
- Relevant dependency PRs:
  - AnacondaRecipes/pybind11-feedstock#24 (pybind11 3.0.4 — **MERGED**)
  - AnacondaRecipes/repodata-hotfixes#318 (scope reduction — **applied**)

### Explanation of changes:

- **Build number 0 -> 1** (no source change). Rebuild against pybind11 3.0.4 from pkgs/main.
- **Result:** the new CPU/MPS artifacts will declare `pybind11-abi ==11` via pybind11-abi's run_export.
- **Why:** torchaudio exchanges torch::Tensor C++ types cross-module with pytorch. Per Charles's PKG-13552 hotfix-scope analysis, retained in the slim `MISSING_PYBIND11_ABI_VERSION_RANGES` table after #318.

[PKG-14949]: https://anaconda.atlassian.net/browse/PKG-14949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-13552]: https://anaconda.atlassian.net/browse/PKG-13552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ