### PR TITLE
PKG-14949: rebuild torchaudio 2.11.0 (CPU/MPS) against pybind11 3.0.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 # Torchaudio and PyTorch are tightly coupled in terms of versions.
 # check the [releases page](https://github.com/pytorch/audio/releases) for compatibility.
 
-{% set build = 0 %}
+{% set build = 1 %}
 # Use a higher build number for the GPU variants, to ensure that they're
 # preferred by conda's solver, and they're preferentially
 # installed where the platform supports it.
@@ -62,7 +62,11 @@ requirements:
     - pytorch ={{ version }}.*=*{{ gpu_variant }}*
     - __cuda                                      # [gpu_variant == "cuda"]
     - libtorch ={{ version }}.*=*{{ gpu_variant }}*
-    - pybind11 2.13.6
+    # pybind11 itself not needed: upstream uses torch.utils.cpp_extension
+    # which bundles pybind11 headers via libtorch/pytorch host deps above.
+    # pybind11-abi propagates the run_export pin (==11) for cross-module
+    # ABI safety with the corresponding pytorch build.
+    - pybind11-abi
     - llvm-openmp                                 # [osx]
     - cuda-version {{ cuda_compiler_version }}    # [gpu_variant == "cuda"]
     - cuda-cudart-dev                             # [gpu_variant == "cuda"]


### PR DESCRIPTION
torchaudio 2.11.0 (CPU/MPS variant)

**Destination channel:** Defaults
**Base branch:** `main-cpu` (long-lived CPU/MPS release track)

### Links
- [PKG-14949](https://anaconda.atlassian.net/browse/PKG-14949)
- [PKG-13552](https://anaconda.atlassian.net/browse/PKG-13552) (parent epic)
- Companion PRs (other variants of the same rebuild): cuda129, cuda130
- Dependency: AnacondaRecipes/pybind11-feedstock#24 (pybind11 3.0.4 — **MERGED**)

### Explanation of changes:
- **Build number 0 -> 1** (no source change). Rebuild against pybind11 3.0.4 from pkgs/main.
- **Drop `pybind11 2.13.6` host pin** — vestigial. Upstream uses `torch.utils.cpp_extension` (CppExtension/CUDAExtension), which bundles pybind11 headers via pytorch/libtorch. System pybind11 dep is not used.
- **Add `pybind11-abi` to host** — triggers pybind11-abi's run_export so the rebuilt artifact correctly declares `pybind11-abi ==11` in run deps for cross-module ABI safety with pybind11-v3 built pytorch.
- **Scope:** this PR covers CPU + MPS variants only (cuda variants skipped via existing `gpu_variant == cuda` skip on this branch). cuda129 and cuda130 covered by sibling PRs.

[PKG-14949]: https://anaconda.atlassian.net/browse/PKG-14949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-13552]: https://anaconda.atlassian.net/browse/PKG-13552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ