### PR TITLE
PKG-14949: rebuild torchaudio 2.11.0 (CUDA 12.9) against pybind11 3.0.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 # Torchaudio and PyTorch are tightly coupled in terms of versions.
 # check the [releases page](https://github.com/pytorch/audio/releases) for compatibility.
 
-{% set build = 0 %}
+{% set build = 1 %}
 # Use a higher build number for the GPU variants, to ensure that they're
 # preferred by conda's solver, and they're preferentially
 # installed where the platform supports it.
@@ -62,7 +62,11 @@ requirements:
     - pytorch ={{ version }}.*=*{{ gpu_variant }}*
     - __cuda                                      # [gpu_variant == "cuda"]
     - libtorch ={{ version }}.*=*{{ gpu_variant }}*
-    - pybind11 2.13.6
+    # pybind11 itself not needed: upstream uses torch.utils.cpp_extension
+    # which bundles pybind11 headers via libtorch/pytorch host deps above.
+    # pybind11-abi propagates the run_export pin (==11) for cross-module
+    # ABI safety with the corresponding pytorch build.
+    - pybind11-abi
     - llvm-openmp                                 # [osx]
     - cuda-version {{ cuda_compiler_version }}    # [gpu_variant == "cuda"]
     - cuda-cudart-dev                             # [gpu_variant == "cuda"]


### PR DESCRIPTION
torchaudio 2.11.0 (CUDA 12.9 variant)

**Destination channel:** Defaults
**Base branch:** `main-cuda129` (long-lived CUDA 12.9 release track)

### Links
- [PKG-14949](https://anaconda.atlassian.net/browse/PKG-14949)
- [PKG-13552](https://anaconda.atlassian.net/browse/PKG-13552) (parent epic)
- Sibling PRs: AnacondaRecipes/torchaudio-feedstock#30 (cpu/mps), cuda130 (open)

### Explanation of changes:
Same as the CPU PR but on the cuda129 long-lived branch:
- **Build number 0 -> 1** (no source change). Rebuild against pybind11 3.0.4 from pkgs/main.
- **Drop `pybind11 2.13.6` host pin** — vestigial. Upstream uses `torch.utils.cpp_extension` with bundled pybind11 headers via pytorch/libtorch.
- **Add `pybind11-abi` to host** — triggers run_export so artifact declares `pybind11-abi ==11`.
- **Scope:** CUDA 12.9 only (CPU variants skipped via `gpu_variant == cpu` skip on this branch).

[PKG-14949]: https://anaconda.atlassian.net/browse/PKG-14949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-13552]: https://anaconda.atlassian.net/browse/PKG-13552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ