### PR TITLE
torchaudio 2.11.0 — rebuild against pytorch 2.12 (cpu sweep, 1 of 3)

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -13,7 +13,15 @@ set "LIB=%PREFIX%\Lib\site-packages\torch\lib;%LIBRARY_LIB%;%LIBRARY_PREFIX%\lib
 set "CUDA_HOME=%BUILD_PREFIX%\Library"
 set "CUDA_PATH=%BUILD_PREFIX%\Library"
 
-:: Match pytorch-feedstock's CUDA arch list (libtorch ABI alignment); same for 12.9 and 13.0 on win-64 (x86_64 only)
-set "TORCH_CUDA_ARCH_LIST=7.5;8.0;8.6;9.0;10.0;12.0+PTX"
+:: Match pytorch-feedstock's CUDA arch list. CUDA 12.9 on Win-MSVC hits a
+:: clusterlaunchcontrol.h inline-asm bug (uses "l" 64-bit constraint with 32-bit
+:: long2.x on Windows LLP64; fixed in CUDA 12.9.1 / 13.x). Drop sm_100/sm_120
+:: on CUDA 12.x to avoid pulling that header in via torchaudio's
+:: forced_align/gpu/compute.cu. CUDA 13.x keeps the full list.
+if "%cuda_compiler_version:~0,2%" == "12" (
+  set "TORCH_CUDA_ARCH_LIST=7.5;8.0;8.6;9.0"
+) else (
+  set "TORCH_CUDA_ARCH_LIST=7.5;8.0;8.6;9.0;10.0;12.0+PTX"
+)
 
 %PYTHON% -m pip install . -vv --no-deps --no-build-isolation

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,60 @@
+# gpu_variant is zipped with cuda_compiler_version on win/linux (so the CPU
+# variant doesn't duplicate across CUDA versions) and zipped with
+# MACOSX_DEPLOYMENT_TARGET / CONDA_BUILD_SYSROOT on osx-arm64 (so CPU and
+# Metal builds get the right SDK). Mirrors pytorch-feedstock's CBC pattern
+# so the per-variant PRs (cpu / cuda 12.9 / cuda 13.0) share an identical
+# recipe — only the meta.yaml `build.skip` selector differs.
+#
+# The two `cuda` rows are intentional, NOT a typo. They pair row-wise with
+# `cuda_compiler_version: [none, none, 12.9, 13.0]` via the zip_keys block:
+#   row 3 (selector: win or linux-x86_64) pairs with cuda_compiler_version 12.9
+#   row 4 (selector: win or linux)        pairs with cuda_compiler_version 13.0
+# linux-aarch64 only matches the second cuda line, so it builds cuda 13.0 only
+# (CUDA 12.x requires gcc <15 but aarch64 needs gcc 15.2.0).
 gpu_variant:
-  - cpu
+  - cpu                              # all platforms
+  - metal                            # [(osx and arm64)]
+  - cuda                             # [win or (linux and x86_64)]
+  - cuda                             # [win or linux]
+
+# Linux aarch64 needs gcc 15.2.0 due to vector-instruction bug in 14.3.
+# Linux x86_64 pinned to gcc 14 for CUDA 12.x compatibility (matches
+# pytorch-feedstock so libtorch ABI aligns with the pytorch on pkgs/main).
+c_compiler_version:
+  - 15.2.0                   # [linux and aarch64]
+  - 14                       # [linux and x86_64]
+cxx_compiler_version:
+  - 15.2.0                   # [linux and aarch64]
+  - 14                       # [linux and x86_64]
+
+# pkgs/main ships cuda-nvcc 12.9 and 13.0. aarch64 only supports CUDA 13.x.
+# "none" pairs with gpu_variant=cpu/metal under zip_keys; the recipe ignores
+# cuda_compiler_version for non-CUDA variants but the key must align lengthwise.
+cuda_compiler_version:
+  - none                             # cpu
+  - none                             # [(osx and arm64)]  # metal pair
+  - 12.9                             # [win or (linux and x86_64)]
+  - 13.0                             # [win or linux]
+
+# Both CPU and Metal build against SDK 13.3 (torchvision Metal does not need
+# the newer SDK 14.5 that pytorch uses for its Metal backend). Kept here so
+# the zip_keys on osx-arm64 line up with the two gpu_variant rows.
+MACOSX_DEPLOYMENT_TARGET:    # [(osx and arm64)]
+  - 13.3                     # [(osx and arm64)]
+  - 13.3                     # [(osx and arm64)]
+CONDA_BUILD_SYSROOT:         # [(osx and arm64)]
+  - /Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk  # [(osx and arm64)]
+  - /Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk  # [(osx and arm64)]
+
+# Two zip groups, gated by platform so the shared `gpu_variant` key doesn't conflict:
+#   - osx-arm64: zip gpu_variant with the two SDK keys (cpu↔13.3, metal↔13.3).
+#   - win/linux: zip gpu_variant with cuda_compiler_version so the CPU variant
+#                exists exactly once per platform (no Cartesian-product duplicates).
+zip_keys:
+  -                              # [(osx and arm64)]
+    - gpu_variant                # [(osx and arm64)]
+    - MACOSX_DEPLOYMENT_TARGET   # [(osx and arm64)]
+    - CONDA_BUILD_SYSROOT        # [(osx and arm64)]
+  -                              # [win or linux]
+    - gpu_variant                # [win or linux]
+    - cuda_compiler_version      # [win or linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,14 @@
 # Rebuild against pytorch 2.12.0: upstream torchaudio is in maintenance mode
 # (see pytorch/audio#3902) and no 2.12 tag exists; bump build number only so the
 # 2.11 binaries link against the pytorch 2.12.0 libtorch ABI.
+# Build target -> host stays strict at 2.12.0 to control which libtorch we link.
 {% set compatible_pytorch = "2.12.0" %}
+# Run lower bound -> per torchaudio 2.11's setup_helpers/extension.py:62
+# (TORCH_TARGET_VERSION=0x020a000000000000 = pytorch 2.10) + libtorch stable-ABI
+# guarantees, this binary is forward-compatible with any pytorch >= 2.12; allows
+# the same _1 / _101 build to serve future pytorch 2.13/2.14/... users without
+# another rebuild. (Charles Bousseau review, PR #33.)
+{% set compatible_pytorch_run = "2.12" %}
 {% set run_all_unittests = False %}
 # Torchaudio and PyTorch are tightly coupled in terms of versions.
 # check the [releases page](https://github.com/pytorch/audio/releases) for compatibility.
@@ -31,8 +38,8 @@ build:
   number: {{ build }}
   string: cpu_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                # [gpu_variant == "cpu"]
   string: cuda{{ cuda_compiler_version | replace('.', '') }}py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [gpu_variant == "cuda"]
-  # CPU split PR — skip non-cpu builds (torchaudio has no MPS/metal backend; per unified-recipe design: identical across cpu/cuda129/cuda130 PRs except this line)
-  skip: true  # [gpu_variant != "cpu"]
+  # CUDA 13.0 split PR — skip everything but cuda 13.0 (per unified-recipe design: identical across cpu/cuda129/cuda130 PRs except this line)
+  skip: true  # [gpu_variant != "cuda" or cuda_compiler_version != "13.0"]
   missing_dso_whitelist:
     - "**/libc10.so"                # [linux]
     - "**/libtorch_cpu.so"          # [linux]
@@ -89,7 +96,7 @@ requirements:
     - cuda-crt-dev_{{ target_platform }}          # [gpu_variant == "cuda"]
   run:
     - python
-    - pytorch ={{ compatible_pytorch }}.*=*{{ gpu_variant }}*
+    - pytorch >={{ compatible_pytorch_run }} *{{ gpu_variant }}*
     - __cuda                                      # [gpu_variant == "cuda"]
 
 # Upstream has been in maintenance mode since 2.9.1: backend and io modules removed

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,10 +1,14 @@
 {% set name = "torchaudio" %}
 {% set version = "2.11.0" %}
+# Rebuild against pytorch 2.12.0: upstream torchaudio is in maintenance mode
+# (see pytorch/audio#3902) and no 2.12 tag exists; bump build number only so the
+# 2.11 binaries link against the pytorch 2.12.0 libtorch ABI.
+{% set compatible_pytorch = "2.12.0" %}
 {% set run_all_unittests = False %}
 # Torchaudio and PyTorch are tightly coupled in terms of versions.
 # check the [releases page](https://github.com/pytorch/audio/releases) for compatibility.
 
-{% set build = 0 %}
+{% set build = 1 %}
 # Use a higher build number for the GPU variants, to ensure that they're
 # preferred by conda's solver, and they're preferentially
 # installed where the platform supports it.
@@ -25,10 +29,10 @@ source:
 
 build:
   number: {{ build }}
-  # CPU/MPS-only split PR — skip CUDA builds (no-op when CBC has no cuda variant)
-  skip: true  # [gpu_variant == "cuda"]
   string: cpu_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                # [gpu_variant == "cpu"]
   string: cuda{{ cuda_compiler_version | replace('.', '') }}py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [gpu_variant == "cuda"]
+  # CPU split PR — skip CUDA builds (per unified-recipe design: identical across cpu/cuda129/cuda130 PRs except this line)
+  skip: true  # [gpu_variant == "cuda"]
   missing_dso_whitelist:
     - "**/libc10.so"                # [linux]
     - "**/libtorch_cpu.so"          # [linux]
@@ -59,10 +63,16 @@ requirements:
     - setuptools
     - wheel
     - pip
-    - pytorch ={{ version }}.*=*{{ gpu_variant }}*
+    - pytorch ={{ compatible_pytorch }}.*=*{{ gpu_variant }}*
     - __cuda                                      # [gpu_variant == "cuda"]
-    - libtorch ={{ version }}.*=*{{ gpu_variant }}*
-    - pybind11 2.13.6
+    - libtorch ={{ compatible_pytorch }}.*=*{{ gpu_variant }}*
+    # libtorch's torch/csrc/Exceptions.h does #include <pybind11/pybind11.h>;
+    # the header is not vendored under libtorch's include tree, so pybind11
+    # must be on the host include path. Matches pytorch-feedstock 2.12 pin.
+    - pybind11 >=3.0.1,<4
+    # pybind11-abi propagates the run_export pin (==11) for cross-module
+    # ABI safety with the corresponding pytorch 2.12 build.
+    - pybind11-abi ==11
     - llvm-openmp                                 # [osx]
     - cuda-version {{ cuda_compiler_version }}    # [gpu_variant == "cuda"]
     - cuda-cudart-dev                             # [gpu_variant == "cuda"]
@@ -79,7 +89,7 @@ requirements:
     - cuda-crt-dev_{{ target_platform }}          # [gpu_variant == "cuda"]
   run:
     - python
-    - pytorch ={{ version }}.*=*{{ gpu_variant }}*
+    - pytorch ={{ compatible_pytorch }}.*=*{{ gpu_variant }}*
     - __cuda                                      # [gpu_variant == "cuda"]
 
 # Upstream has been in maintenance mode since 2.9.1: backend and io modules removed

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,8 +38,8 @@ build:
   number: {{ build }}
   string: cpu_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                # [gpu_variant == "cpu"]
   string: cuda{{ cuda_compiler_version | replace('.', '') }}py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [gpu_variant == "cuda"]
-  # CUDA 13.0 split PR — skip everything but cuda 13.0 (per unified-recipe design: identical across cpu/cuda129/cuda130 PRs except this line)
-  skip: true  # [gpu_variant != "cuda" or cuda_compiler_version != "13.0"]
+  # CPU split PR — skip non-cpu builds (torchaudio has no MPS/metal backend; per unified-recipe design: identical across cpu/cuda129/cuda130 PRs except this line)
+  skip: true  # [gpu_variant != "cpu"]
   missing_dso_whitelist:
     - "**/libc10.so"                # [linux]
     - "**/libtorch_cpu.so"          # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,8 +31,8 @@ build:
   number: {{ build }}
   string: cpu_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                # [gpu_variant == "cpu"]
   string: cuda{{ cuda_compiler_version | replace('.', '') }}py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [gpu_variant == "cuda"]
-  # CPU split PR — skip CUDA builds (per unified-recipe design: identical across cpu/cuda129/cuda130 PRs except this line)
-  skip: true  # [gpu_variant == "cuda"]
+  # CPU split PR — skip non-cpu builds (torchaudio has no MPS/metal backend; per unified-recipe design: identical across cpu/cuda129/cuda130 PRs except this line)
+  skip: true  # [gpu_variant != "cpu"]
   missing_dso_whitelist:
     - "**/libc10.so"                # [linux]
     - "**/libtorch_cpu.so"          # [linux]


### PR DESCRIPTION
torchaudio 2.11.0 — rebuild against pytorch 2.12 (cpu sweep, 1 of 3)

**Destination channel:** defaults

### Links

- [PKG-14842](https://anaconda.atlassian.net/browse/PKG-14842) — torchaudio 2.11 rebuild for pytorch 2.12 (parent: [PKG-12876](https://anaconda.atlassian.net/browse/PKG-12876) Pytorch 2.12)
- [Upstream repository](https://github.com/pytorch/audio)
- [Upstream maintenance-mode notice](https://github.com/pytorch/audio/issues/3902) — no torchaudio 2.12 release planned
- Sibling PRs in this 3-PR split (recipe byte-identical except `build.skip` selector):
  - [#34](https://github.com/AnacondaRecipes/torchaudio-feedstock/pull/34) — cuda 12.9 (2 of 3)
  - [#35](https://github.com/AnacondaRecipes/torchaudio-feedstock/pull/35) — cuda 13.0 (3 of 3)

### Explanation of changes:

- **Rebuild only** (version stays 2.11.0): re-link against pytorch 2.12.0 libtorch ABI so torchaudio is installable alongside pytorch 2.12 on pkgs/main. The shipped 2.11.0 builds pin `pytorch >=2.11.0,<2.12.0a0` and are otherwise unsatisfiable.
- **3 PRs are byte-identical except the single `build.skip` cuda-variant selector line.** This PR's skip: `skip: true  # [gpu_variant == "cuda"]`.

[PKG-14842]: https://anaconda.atlassian.net/browse/PKG-14842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-12876]: https://anaconda.atlassian.net/browse/PKG-12876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
